### PR TITLE
Work with remote URLs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,8 @@ package_dir =
 packages = find_namespace:
 install_requires =
     stactools >= 0.3.1
+    pandas
+    stac-table@git+https://github.com/TomAugspurger/stac-table
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Updates `stac.create_item` to optionally accept a protocol and storage options for working with files directly from blob storage (which is how we'll use it for the Planetary Computer).

```python
>>> from stactools.kaza_hydroforecast import stac
>>> import planetary_computer
>>> item = stac.create_item(
...     "hydroforecast/hydroforecast_seasonal_bar_4_zambezi.parquet",
...     protocol="abfs",
...     storage_options={"account_name": "ai4edataeuwest", "credential": planetary_computer.sas.get_token("ai4edataeuwest", "hydroforecast").token},
...     asset_extra_fields={"account_name": "ai4edataeuwest"}
... )
```